### PR TITLE
adjust build targets

### DIFF
--- a/rust/makefile
+++ b/rust/makefile
@@ -50,7 +50,7 @@ target/universal/release/libexample.a: $(SOURCES) ndk-home
 		else echo "Skipping iOS compilation on $$(uname)" ; \
 	fi
 
-## android: Compile the android targets (arm64, armv7 and i686)
+## android: Compile the android targets (arm64, x86_64, armv7 and i686)
 android: target/aarch64-linux-android/release/libexample.so target/armv7-linux-androideabi/release/libexample.so target/i686-linux-android/release/libexample.so target/x86_64-linux-android/release/libexample.so
 
 target/aarch64-linux-android/release/libexample.so: $(SOURCES) ndk-home
@@ -68,9 +68,9 @@ target/i686-linux-android/release/libexample.so: $(SOURCES) ndk-home
 	CARGO_TARGET_I686_LINUX_ANDROID_LINKER=$(ANDROID_I686_LINKER) \
 		cargo  build --target i686-linux-android --release
 
-target/x86_64-linux-android/release/libexample.so: $(SOURCES) ndk-home
-    CC_x86_64_linux_android=$(ANDROID_I686_LINKER) \
-    CARGO_TARGET_X86_64_LINUX_ANDROID_LINKER=$(ANDROID_I686_LINKER) \
+target/x86-64-linux-android/release/libexample.so: $(SOURCES) ndk-home
+    CC_x86_64_linux_android=$(ANDROID_X86_64_LINKER) \
+    CARGO_TARGET_X86_64_LINUX_ANDROID_LINKER=$(ANDROID_X86_64_LINKER) \
         cargo  build --target x86_64-linux-android --release
 
 .PHONY: ndk-home

--- a/rust/makefile
+++ b/rust/makefile
@@ -8,6 +8,7 @@ PATH := $(ANDROID_NDK_HOME)/toolchains/llvm/prebuilt/$(OS_NAME)-x86_64/bin:$(PAT
 ANDROID_AARCH64_LINKER=$(ANDROID_NDK_HOME)/toolchains/llvm/prebuilt/$(OS_NAME)-x86_64/bin/aarch64-linux-android29-clang
 ANDROID_ARMV7_LINKER=$(ANDROID_NDK_HOME)/toolchains/llvm/prebuilt/$(OS_NAME)-x86_64/bin/armv7a-linux-androideabi29-clang
 ANDROID_I686_LINKER=$(ANDROID_NDK_HOME)/toolchains/llvm/prebuilt/$(OS_NAME)-x86_64/bin/i686-linux-android29-clang
+ANDROID_X86_64_LINKER=$(ANDROID_NDK_HOME)/toolchains/llvm/prebuilt/$(OS_NAME)-x86_64/bin/x86_64-linux-android29-clang
 
 SHELL := /bin/bash
 
@@ -26,8 +27,8 @@ help: makefile
 ## init: Install missing dependencies.
 .PHONY: init
 init:
-	rustup target add aarch64-apple-ios armv7-apple-ios armv7s-apple-ios x86_64-apple-ios i386-apple-ios
-	rustup target add aarch64-linux-android armv7-linux-androideabi i686-linux-android
+	rustup target add aarch64-apple-ios x86_64-apple-ios
+	rustup target add aarch64-linux-android armv7-linux-androideabi i686-linux-android x86_64-linux-android
 	@if [ $$(uname) == "Darwin" ] ; then cargo install cargo-lipo ; fi
 	cargo install cbindgen
 
@@ -50,7 +51,7 @@ target/universal/release/libexample.a: $(SOURCES) ndk-home
 	fi
 
 ## android: Compile the android targets (arm64, armv7 and i686)
-android: target/aarch64-linux-android/release/libexample.so target/armv7-linux-androideabi/release/libexample.so target/i686-linux-android/release/libexample.so
+android: target/aarch64-linux-android/release/libexample.so target/armv7-linux-androideabi/release/libexample.so target/i686-linux-android/release/libexample.so target/x86_64-linux-android/release/libexample.so
 
 target/aarch64-linux-android/release/libexample.so: $(SOURCES) ndk-home
 	CC_aarch64_linux_android=$(ANDROID_AARCH64_LINKER) \
@@ -66,6 +67,11 @@ target/i686-linux-android/release/libexample.so: $(SOURCES) ndk-home
 	CC_i686_linux_android=$(ANDROID_I686_LINKER) \
 	CARGO_TARGET_I686_LINUX_ANDROID_LINKER=$(ANDROID_I686_LINKER) \
 		cargo  build --target i686-linux-android --release
+
+target/x86_64-linux-android/release/libexample.so: $(SOURCES) ndk-home
+    CC_x86_64_linux_android=$(ANDROID_I686_LINKER) \
+    CARGO_TARGET_X86_64_LINUX_ANDROID_LINKER=$(ANDROID_I686_LINKER) \
+        cargo  build --target x86_64-linux-android --release
 
 .PHONY: ndk-home
 ndk-home:


### PR DESCRIPTION
Thanks for the template and clear explaination on Medium!

This PR adjusts (adds and removes) some targets

### Android 

Add support for `x86_64_linux`, closes #3 

### iOS 

remove 32 bits target: `i386`, `armb7s`, `armv7` targets

because:

From 1.42.0 rust [dropped 32-bit apple target support](https://blog.rust-lang.org/2020/01/03/reducing-support-for-32-bit-apple-targets.html)), the latest version for building ios target is 1.41.1.

In addition to that, as of Xcode 10 (10A255) - September 17, 2018, i386 architecture is no longer supported.

References of ios archs and devices could be refer [here](https://developer.apple.com/library/archive/documentation/DeviceInformation/Reference/iOSDeviceCompatibility/DeviceCompatibilityMatrix/DeviceCompatibilityMatrix.html).
